### PR TITLE
Refactor: Remove unused ChevronsUpDown icon and adjust icon sizes

### DIFF
--- a/client/src/components/flight-search-form.tsx
+++ b/client/src/components/flight-search-form.tsx
@@ -12,7 +12,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { Calendar } from "@/components/ui/calendar";
 import { format } from "date-fns";
-import { Check, ChevronsUpDown, Calendar as CalendarIcon, ArrowRightLeft, PlaneTakeoff, PlaneLanding, Search } from "lucide-react";
+import { Check, Calendar as CalendarIcon, ArrowRightLeft, PlaneTakeoff, PlaneLanding, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { flightSearchSchema } from "@shared/schema";
 import type { FlightSearchFormData } from "@/lib/types";
@@ -135,7 +135,6 @@ export default function FlightSearchForm({ className }: FlightSearchFormProps) {
                               <PlaneTakeoff className="h-5 w-5 text-gray-400" />
                               <span>{field.value || "Select departure"}</span>
                             </div>
-                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                           </Button>
                         </FormControl>
                       </PopoverTrigger>
@@ -199,7 +198,6 @@ export default function FlightSearchForm({ className }: FlightSearchFormProps) {
                                 <PlaneLanding className="h-5 w-5 text-gray-400" />
                                 <span>{field.value || "Select destination"}</span>
                               </div>
-                              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                             </Button>
                           </FormControl>
                         </PopoverTrigger>
@@ -240,11 +238,11 @@ export default function FlightSearchForm({ className }: FlightSearchFormProps) {
                         type="button"
                         variant="ghost"
                         size="sm"
-                        className="absolute right-2 top-1/2 -translate-y-1/2 h-8 w-8 p-0"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 h-8 w-8 p-0 [&_svg]:!size-5"
                         onClick={swapAirports}
                         data-testid="swap-airports"
                       >
-                        <ArrowRightLeft className="h-4 w-4" />
+                        <ArrowRightLeft className="h-5 w-5" />
                       </Button>
                     </div>
                     <FormMessage />

--- a/client/src/components/flight-search/search-form.tsx
+++ b/client/src/components/flight-search/search-form.tsx
@@ -12,7 +12,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { Calendar } from "@/components/ui/calendar";
 import { format } from "date-fns";
-import { Check, ChevronsUpDown, Calendar as CalendarIcon, ArrowRightLeft, PlaneTakeoff, PlaneLanding, Search } from "lucide-react";
+import { Check, Calendar as CalendarIcon, ArrowRightLeft, PlaneTakeoff, PlaneLanding, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { flightSearchSchema } from "@shared/schema";
 import type { FlightSearchFormData } from "@/lib/types";
@@ -135,7 +135,6 @@ export default function SearchForm({ className }: SearchFormProps) {
                               <PlaneTakeoff className="h-5 w-5 text-gray-400" />
                               <span>{field.value || "Select departure"}</span>
                             </div>
-                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                           </Button>
                         </FormControl>
                       </PopoverTrigger>
@@ -199,7 +198,6 @@ export default function SearchForm({ className }: SearchFormProps) {
                                 <PlaneLanding className="h-5 w-5 text-gray-400" />
                                 <span>{field.value || "Select destination"}</span>
                               </div>
-                              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                             </Button>
                           </FormControl>
                         </PopoverTrigger>
@@ -240,11 +238,11 @@ export default function SearchForm({ className }: SearchFormProps) {
                         type="button"
                         variant="ghost"
                         size="sm"
-                        className="absolute right-2 top-1/2 -translate-y-1/2 h-8 w-8 p-0"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 h-8 w-8 p-0 [&_svg]:!size-5"
                         onClick={swapAirports}
                         data-testid="swap-airports"
                       >
-                        <ArrowRightLeft className="h-4 w-4" />
+                        <ArrowRightLeft className="h-5 w-5" />
                       </Button>
                     </div>
                     <FormMessage />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes ChevronsUpDown icons from From/To selectors and enlarges the swap ArrowRightLeft icon in both flight search forms.
> 
> - **Frontend/UI**
>   - **Flight search forms** (`client/src/components/flight-search-form.tsx`, `client/src/components/flight-search/search-form.tsx`):
>     - Remove `ChevronsUpDown` imports and chevron icons from `From` and `To` selector buttons.
>     - Adjust swap button styling: add `[&_svg]:!size-5` and increase `ArrowRightLeft` icon from `h-4 w-4` to `h-5 w-5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e677eeffce3cbb3c345a12731b595c4e9c3afe3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->