### PR TITLE
Handle window undefined in i18n functions

### DIFF
--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -148,15 +148,18 @@ const dictionaries: Record<Locale, Dictionary> = {
 };
 
 export function t(key: string): string {
-  const locale = getLocaleFromPath(window.location.pathname);
+  const pathname = typeof window !== "undefined" && window.location ? window.location.pathname : "/";
+  const locale = getLocaleFromPath(pathname);
   const dict = dictionaries[locale] || dictionaries.en;
   return dict[key] ?? dictionaries.en[key] ?? key;
 }
 
 export function useI18n() {
-  const locale = getLocaleFromPath(window.location.pathname);
+  const pathname = typeof window !== "undefined" && window.location ? window.location.pathname : "/";
+  const locale = getLocaleFromPath(pathname);
   const href = (path: string) => buildLocalizedPath(locale, path);
   const switchLocale = (newLocale: Locale) => {
+    if (typeof window === "undefined" || !window.location) return;
     const next = replaceLocaleInPath(window.location.pathname + window.location.search + window.location.hash, newLocale);
     window.location.assign(next);
   };


### PR DESCRIPTION
Guard `window.location` access in `t` and `useI18n` to prevent runtime errors in server-side rendering environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-8451d9ec-d452-4852-89e8-d36613e84a39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8451d9ec-d452-4852-89e8-d36613e84a39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard `window.location` access in `client/src/lib/i18n.ts` by defaulting `pathname` to `/` when unavailable and early-returning in `switchLocale` for SSR safety.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c26d8ec406834a98b301d2d8be60985ab1ccfe2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->