### PR TITLE
fix(header): correct active state by end-anchoring regexes and standa…

### DIFF
--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -17,11 +17,11 @@ export default function Header() {
   const { locale, switchLocale, href, t } = useI18n();
 
   const navigation = [
-    { name: t("header_book"), href: href("/"), current: new RegExp(`^/${locale}/?$`).test(location) },
-    { name: t("header_checkin"), href: href("/checkin"), current: new RegExp(`^/${locale}/checkin`).test(location) },
-    { name: t("header_destinations"), href: href("/destinations"), current: new RegExp(`^/${locale}/destinations`).test(location) },
-    { name: t("header_offers"), href: href("/offers"), current: new RegExp(`^/${locale}/offers`).test(location) },
-    { name: t("header_my_booking"), href: href("/my-booking"), current: new RegExp(`^/${locale}/my-booking`).test(location) },
+    { name: t("header_book"), href: href("/"), match: new RegExp(`^/${locale}/?$`).test(location) },
+    { name: t("header_checkin"), href: href("/checkin"), match: new RegExp(`^/${locale}/checkin/?$`).test(location) },
+    { name: t("header_destinations"), href: href("/destinations"), match: new RegExp(`^/${locale}/destinations/?$`).test(location) },
+    { name: t("header_offers"), href: href("/offers"), match: new RegExp(`^/${locale}/offers/?$`).test(location) },
+    { name: t("header_my_booking"), href: href("/my-booking"), match: new RegExp(`^/${locale}/my-booking/?$`).test(location) },
   ];
 
   return (
@@ -45,7 +45,7 @@ export default function Header() {
                 key={item.name}
                 href={item.href}
                 className={`font-medium transition-colors ${
-                  item.current
+                  item.match
                     ? "text-sunblue"
                     : "text-gray-700 hover:text-sunblue"
                 }`}
@@ -92,7 +92,7 @@ export default function Header() {
                       <Link
                         href={item.href}
                         className={`text-lg font-medium transition-colors ${
-                          item.current
+                          item.match
                             ? "text-sunblue"
                             : "text-gray-700 hover:text-sunblue"
                         }`}

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -18,10 +18,10 @@ export default function Header() {
 
   const navigation = [
     { name: t("header_book"), href: href("/"), match: new RegExp(`^/${locale}/?$`).test(location) },
-    { name: t("header_checkin"), href: href("/checkin"), match: new RegExp(`^/${locale}/checkin`).test(location) },
-    { name: t("header_destinations"), href: href("/destinations"), match: new RegExp(`^/${locale}/destinations`).test(location) },
-    { name: t("header_offers"), href: href("/offers"), match: new RegExp(`^/${locale}/offers`).test(location) },
-    { name: t("header_my_booking"), href: href("/my-booking"), match: new RegExp(`^/${locale}/my-booking`).test(location) },
+    { name: t("header_checkin"), href: href("/checkin"), match: new RegExp(`^/${locale}/checkin/?$`).test(location) },
+    { name: t("header_destinations"), href: href("/destinations"), match: new RegExp(`^/${locale}/destinations/?$`).test(location) },
+    { name: t("header_offers"), href: href("/offers"), match: new RegExp(`^/${locale}/offers/?$`).test(location) },
+    { name: t("header_my_booking"), href: href("/my-booking"), match: new RegExp(`^/${locale}/my-booking/?$`).test(location) },
   ];
 
   return (


### PR DESCRIPTION
…rdize to match property

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes active state to `match` and end-anchors route regexes (with optional trailing slash) across header components.
> 
> - **Frontend**
>   - **`client/src/components/header.tsx`**:
>     - Rename `current` to `match` in `navigation` and update usage in desktop/mobile links.
>     - End-anchor route regexes and allow optional trailing slash for `checkin`, `destinations`, `offers`, `my-booking`.
>   - **`client/src/components/layout/header.tsx`**:
>     - Refine `match` regexes to be end-anchored with optional trailing slash for non-root routes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efe014062d45ae7308c927d7499bd3b8280bec51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->